### PR TITLE
指摘修正01

### DIFF
--- a/backend/app/Http/Controllers/DefaultController.php
+++ b/backend/app/Http/Controllers/DefaultController.php
@@ -19,7 +19,7 @@ class DefaultController extends Controller
      */
     public function viewAction(Request $request){
         $status = config('const.workshop.status.published');
-        $workshopList = Workshop::fetchList($status, null, null, 3);
+        $workshopList = Workshop::fetchList($status, null, null, 3, null);
        return view('top', ['workshopList' => $workshopList]);
     }
 	

--- a/backend/app/Http/Controllers/MyPageController.php
+++ b/backend/app/Http/Controllers/MyPageController.php
@@ -20,7 +20,7 @@ class MyPageController extends Controller
     public function myWorkshop(Request $request)
     {
       $status = $request->input('status') ?? config('const.workshop.status.published');
-      $workshops = Workshop::fetchList($status, Auth::id(), null, null);
+      $workshops = Workshop::fetchList($status, Auth::id(), null, null, true);
       
       return view('mypage.my-workshop', ['status' => $status, 'workshops' => $workshops]);
     }
@@ -34,7 +34,7 @@ class MyPageController extends Controller
     public function joinedWorkshop(Request $request)
     {
       $status = $request->input('status') ?? config('const.workshop.status.published');
-      $workshops = Workshop::fetchList($status, Auth::id(), null, null);
+      $workshops = Workshop::fetchList($status, Auth::id(), null, null, false);
       
       return view('mypage.joined-workshop', ['status' => $status, 'workshops' => $workshops]);
     }

--- a/backend/app/Http/Controllers/SearchController.php
+++ b/backend/app/Http/Controllers/SearchController.php
@@ -20,7 +20,7 @@ class SearchController extends Controller
             'category' => $request->input('category'),
             'area' => $request->input('venue_id'),
         ];
-        $searchResult = Workshop::fetchList($status, null, $searchPram, null);
+        $searchResult = Workshop::fetchList($status, null, $searchPram, null, null);
         return view('search.list', ['workshops' => $searchResult]);
     }
 }

--- a/backend/app/Http/Controllers/Workshops/WorkshopController.php
+++ b/backend/app/Http/Controllers/Workshops/WorkshopController.php
@@ -15,6 +15,7 @@ class WorkshopController extends Controller
 {
     /**
      * 一覧表示
+     * MyPageに移行。現在使ってない
      *
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
@@ -22,7 +23,7 @@ class WorkshopController extends Controller
     public function index(Request $request)
     {
         $status = $request->input('status') ?? config('const.workshop.status.published');
-        $workshopList = Workshop::fetchList($status, Auth::id(), null, null);
+        $workshopList = Workshop::fetchList($status, Auth::id(), null, null, true);
         return view('workshops.list', ['status' => $status, 'workshops' => $workshopList ]);
     }
 
@@ -50,6 +51,7 @@ class WorkshopController extends Controller
             'venue_id' => 'required',
             'venue' => 'required|max:255',
             'description' => 'required|min:20|max:2000',
+            'category_id' => 'required',
             'eventDateTime' => 'required|date',
             'caution' => 'required|max:255',
             'cancellationDeadline' => 'required|date|before_or_equal:eventDateTime',
@@ -142,7 +144,7 @@ class WorkshopController extends Controller
             $request->session()->pull('isEdit')
         );
 
-        return redirect(route('workshop.list'));
+        return redirect(route('mypage.my-workshop'));
     }
 
     /**
@@ -353,6 +355,6 @@ class WorkshopController extends Controller
             $workshop = new Workshop();
             $workshop->deleteById($workshopId);
         });
-        return redirect(route('workshop.list'));
+        return redirect(route('mypage.my-workshop'));
     }
 }

--- a/backend/public/css/app.css
+++ b/backend/public/css/app.css
@@ -570,7 +570,7 @@ video {
      -moz-appearance: none;
           appearance: none;
   background-color: #fff;
-  border-color: #C1C1C1;
+  border-color: #6b7280;
   border-width: 1px;
   border-radius: 0px;
   padding-top: 0.5rem;
@@ -656,7 +656,7 @@ select {
   width: 1rem;
   color: #2563eb;
   background-color: #fff;
-  border-color: #C1C1C1;
+  border-color: #6b7280;
   border-width: 1px;
 }
 

--- a/backend/resources/lang/ja/validation.php
+++ b/backend/resources/lang/ja/validation.php
@@ -155,6 +155,7 @@ return [
         'venue_id' => '開催地（都道府県）',
         'venue' => '開催地（都道府県以降）',
         'description' => '紹介文',
+        'category_id' => 'カテゴリ',
         'eventDateTime' => '開催日時',
         'caution' => '注意・警告事項',
         'cancellationDeadline' => 'キャンセル期限',

--- a/backend/resources/views/profile/show.blade.php
+++ b/backend/resources/views/profile/show.blade.php
@@ -4,7 +4,7 @@
                 <ul class="flex flex-wrap text120 text-center bg-gray-100">
                     <li class="w-1/3 bg-gray-200"><a class="block my-3 p-1" href="{{ route('profile.show') }}">{{ __('Profile') }}</a></li>
                     <li class="w-1/3"><a class="block my-3 p-1" href="{{ route('mypage.my-workshop') }}">開催ワークショップ</a></li>
-                    <li class="w-1/3"><a class="block my-3 p-1" href="#">参加ワークショップ</a></li>
+                    <li class="w-1/3"><a class="block my-3 p-1" href="{{ route('mypage.joined-workshop') }}">参加ワークショップ</a></li>
                 </ul>
             </div>
         <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8">

--- a/backend/resources/views/workshops/list.blade.php
+++ b/backend/resources/views/workshops/list.blade.php
@@ -8,7 +8,7 @@
                 {{ Form::open(['url' => route('workshop.create'), 'method' => 'GET']) }}
                     <button type="submit" class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-3 px-8 rounded">新規登録</button>
                 {{ Form::close() }}
-                {{ Form::open(['url' => route('workshop.list'), 'method' => 'GET', 'class' => 'table m-auto']) }}
+                {{ Form::open(['url' => route('mypage.my-workshop'), 'method' => 'GET', 'class' => 'table m-auto']) }}
                     @if ( $status === config('const.workshop.status.published') )
                         <button type="submit" name="status" value={{ config('const.workshop.status.unpublished') }} class="bg-white hover:bg-gray-300 text-gray-400 font-bold py-3 px-7 rounded btn-in-shadow">未公開</button>
                         <button type="submit" name="status" value={{ config('const.workshop.status.published') }} class="bg-white hover:bg-gray-300 text-gray-700 font-bold py-3 px-7 rounded btn-in-shadow">公開</button>

--- a/backend/resources/views/workshops/register.blade.php
+++ b/backend/resources/views/workshops/register.blade.php
@@ -47,7 +47,7 @@
             <!-- カテゴリ -->
             <div class="col-span-6 sm:col-span-4 my-4">
                 {{ Form::label('category_id', __('Category')) }}
-                {{ Form::select('category_id', App\Consts\Category::CATEGORY_LIST_PHYSICS, session('category_id'), ['class' => 'mt-1 block w-full', 'placeholder' => '']) }}
+                {{ Form::select('category_id', App\Consts\Category::CATEGORY_LIST_PHYSICS, session('category_id'), ['class' => 'mt-1 block w-full']) }}
                 @if ($errors->has('description'))
                     <p class="error-msg">{{ $errors->first('category_id') }}</p>
                 @endif

--- a/backend/resources/views/workshops/register.blade.php
+++ b/backend/resources/views/workshops/register.blade.php
@@ -49,7 +49,7 @@
                 {{ Form::label('category_id', __('Category')) }}
                 {{ Form::select('category_id', App\Consts\Category::CATEGORY_LIST_PHYSICS, session('category_id'), ['class' => 'mt-1 block w-full', 'placeholder' => '']) }}
                 @if ($errors->has('description'))
-                    <p class="error-msg">{{ $errors->first('description') }}</p>
+                    <p class="error-msg">{{ $errors->first('category_id') }}</p>
                 @endif
             </div>
 

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -17,13 +17,14 @@ use App\Http\Controllers\MyPageController;
 |
 */
 
+//TOP
 Route::get('/', [DefaultController::class, 'viewAction'])->name('top');
 
 Route::middleware(['auth:sanctum', 'verified'])->get('/dashboard', function () {
     return view('dashboard');
 })->name('dashboard');
 
-// Route::get('/admin', [DefaultController::class, 'viewAction'])->name('top');
+Route::redirect('/dashboard', '/' , 301);
 
 //検索結果一覧
 Route::get('/search', [SearchController::class, 'index'])->name('search.list');
@@ -43,9 +44,7 @@ Route::group(['prefix' => 'mypage', 'middleware' => ['auth:sanctum', 'verified']
 
 /** ワークショップ */
 Route::group(['prefix' => 'workshop', 'middleware' => ['auth:sanctum', 'verified']], function () {
-    // 一覧
-    Route::get('', [WorkshopController::class, 'index'])
-        ->name('workshop.list');
+    //一覧はマイページに移設
     // 詳細
     Route::get('detail', [WorkshopController::class, 'show'])
         ->name('workshop.detail');


### PR DESCRIPTION
1_認証メールの遷移先画面
　⇨`/dashboard`となっていたのでTOP（`/`）に遷移するように変更しました。
2_ワークショップ登録画面のテキスト
　⇨開催地と同様の動作をするように修正しました。選択肢で空欄を選択できなくしています。
3_参加予定のワークショップの表示について
　⇨表示されるように修正しました。また、参加ボタンを押した後にマイページの参加ワークショップへリダイレクトさせるように修正しています。
4_プロフィール画面から参加ワークショップへの画面遷移リンク
　⇨リンクが有効になるように修正しました。